### PR TITLE
Fix Windows installation and remove a deprecated variable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.black]
 line-length = 79
-py36 = true
 
 [tool.isort]
 multi_line_output = 3

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,11 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
+install_packages = ["numpy"]
+
+if os.name == "nt":
+    install_packages.append("pypiwin32")
+
 setup(
     author="spirit",
     author_email="hiddenspirit@gmail.com",
@@ -21,5 +26,5 @@ setup(
     packages=find_packages(),
     package_dir={"ffms2": "ffms2"},
     package_data={"ffms2": ["ffms2/*.*"]},
-    install_requires=["numpy"],
+    install_requires=install_packages,
 )


### PR DESCRIPTION
To load `ffms2` libraries, Windows needs the `pypiwin32` package, so I added it to the requirements.

I have also removed the `py36` variable, because it's deprecated.